### PR TITLE
ci: release renovate patches without a CHANGELOG commit

### DIFF
--- a/.github/workflows/release-golang-executable-on-tag.yaml
+++ b/.github/workflows/release-golang-executable-on-tag.yaml
@@ -9,6 +9,14 @@ on:
       tag:
         required: true
         type: string
+      release_body:
+        description: >-
+          Release notes. Left empty (the default), the CHANGELOG section for the
+          tag is used instead. Callers that cannot add a CHANGELOG entry - a bot
+          commit cannot land on protected main - pass their own text here.
+        required: false
+        type: string
+        default: ""
 
 env:
   TAG: ${{ inputs.tag != '' && inputs.tag || github.ref_name }}
@@ -17,9 +25,12 @@ jobs:
   release-prerequisites:
     runs-on: ubuntu-latest
     outputs:
-      RELEASE_BODY: ${{ steps.release-prerequisites.outputs.RELEASE_BODY }}
+      RELEASE_BODY: ${{ inputs.release_body != '' && inputs.release_body || steps.release-prerequisites.outputs.RELEASE_BODY }}
     steps:
+      # The action's only job is to find the CHANGELOG section for the tag, so it
+      # is skipped when the caller already supplied the body.
       - id: release-prerequisites
+        if: ${{ inputs.release_body == '' }}
         uses: thetillhoff/action-release-prerequisites@2c4e295d06d4b8ce6fe2bdf6a1b7e806d7c1687c # v0.4.1
         with:
           RELEASE_TAG: ${{ env.TAG }}

--- a/.github/workflows/tag-on-main.yaml
+++ b/.github/workflows/tag-on-main.yaml
@@ -11,7 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'renovate[bot]' }}
     outputs:
-      CURRENT_VERSION: ${{ steps.versions.outputs.CURRENT_VERSION }}
       NEW_VERSION: ${{ steps.versions.outputs.NEW_VERSION }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -23,39 +22,10 @@ jobs:
           CURRENT_VERSION=$(git describe --tags --abbrev=0)
           NEW_VERSION=v$(npx semver "$CURRENT_VERSION" -i patch)
 
-          echo "CURRENT_VERSION=$CURRENT_VERSION" >> $GITHUB_OUTPUT
           echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_OUTPUT
 
-  update-changelog:
-    needs: determine-version
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Update CHANGELOG
-        run: |
-          NEW_VERSION="${{ needs.determine-version.outputs.NEW_VERSION }}"
-
-          # Find the line number of the first version entry
-          grep '^## v' CHANGELOG.md # Verify that there is at least one version entry
-          FIRST_VERSION_LINE=$(grep -n '^## v' CHANGELOG.md | head -1 | cut -d: -f1)
-
-          sed -i "${FIRST_VERSION_LINE}i## ${NEW_VERSION}\n\nUpdated dependencies.\n" CHANGELOG.md
-
-      - name: Commit and push CHANGELOG
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add CHANGELOG.md
-          git commit -m "Add CHANGELOG entry for ${NEW_VERSION}"
-          git push
-
   git-tag:
-    needs:
-      - determine-version
-      - update-changelog
+    needs: determine-version
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -65,8 +35,21 @@ jobs:
           git tag "${{ needs.determine-version.outputs.NEW_VERSION }}"
           git push origin "${{ needs.determine-version.outputs.NEW_VERSION }}"
 
+  # A tag pushed with GITHUB_TOKEN does not fire `on: push: tags:`, so the
+  # release has to be called directly. The local path keeps caller and callee on
+  # the same commit; a pinned remote SHA silently runs an older release workflow.
   trigger-release:
-    needs: git-tag
-    uses: thetillhoff/temingo/.github/workflows/release-golang-executable-on-tag.yaml@6b2a36cf7c6ec7c227ce9f9dc7b8b90e0841981b # main
+    needs:
+      - determine-version
+      - git-tag
+    permissions:
+      contents: write
+      packages: write
+    uses: ./.github/workflows/release-golang-executable-on-tag.yaml
     with:
       tag: ${{ needs.determine-version.outputs.NEW_VERSION }}
+      # These releases get no CHANGELOG entry, so the body carries the fixed
+      # text one would have contained. Writing it needed a bot commit on main,
+      # which stops working the moment main requires a passing check: a
+      # GITHUB_TOKEN commit triggers no workflows, so the check never runs.
+      release_body: "Updated dependencies."

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -91,10 +91,12 @@ CI builds 6 targets: `linux`, `darwin`, `windows` × `amd64`, `arm64`. The versi
 
 ## Release Process
 
-1. Renovate bot merges a dependency PR → `tag-on-main.yaml` auto-bumps the patch version and creates a tag.
-2. The tag triggers `release-golang-executable-on-tag.yaml`:
+1. Renovate bot merges a dependency PR → `tag-on-main.yaml` auto-bumps the patch version, tags it, and calls `release-golang-executable-on-tag.yaml` directly (a tag pushed with `GITHUB_TOKEN` does not fire `on: push: tags:`).
+2. That workflow:
    - Builds 6 platform binaries
    - Builds and pushes multi-arch Docker image to `ghcr.io/thetillhoff/temingo`
    - Creates GitHub Release with artifacts
    - Updates Homebrew tap and GoReport card
 3. Manual releases: create and push a `vX.Y.Z` tag.
+
+The release body comes from the `CHANGELOG.md` section for the tag, and the release fails if there is none - so a manual release needs its entry written first. Automated dependency patches have no entry: `tag-on-main` passes `release_body: "Updated dependencies."` instead, and `CHANGELOG.md` skips those version numbers.


### PR DESCRIPTION
Same shape as thetillhoff/webscan#171, so both repos release the same way.

On webscan this was a hard break: `update-changelog` pushes its CHANGELOG commit to protected `main`, a `GITHUB_TOKEN` commit gets no CI, so the required check is unsatisfiable and the push is rejected permanently. Here `main` has no required check yet, so the commit does land - but the entry it writes is the fixed string `Updated dependencies.`, which the release body carries just as well, and the job becomes a liability the moment a check is required.

- `release-golang-executable-on-tag` takes an optional `release_body` and skips `action-release-prerequisites` (whose only job is locating the CHANGELOG section) when it is set.
- `tag-on-main` drops `update-changelog` and passes `release_body: "Updated dependencies."`.
- Manual releases pass nothing, so the CHANGELOG path is unchanged - and still fails the release if the entry is missing.

### Two bugs found on the way

- `trigger-release` read `needs.determine-version.outputs.NEW_VERSION` without listing `determine-version` in `needs`, so the `tag` input was always empty and the release workflow fell back to `github.ref_name` - `main`, not a version.
- It called the release workflow via a remote SHA pinned to an old `main`, which quietly runs an outdated copy and would have rejected the new input. Switched to the local `./.github/workflows/...` path, which keeps caller and callee on one commit. `permissions` is declared on the calling job, since a called workflow cannot exceed its caller's grant.

**Cost:** `CHANGELOG.md` skips the version numbers of dependency-only patches. No content is lost - the text still appears as the GitHub release body.

Verified with `actionlint` (exit 0; the one shellcheck note is pre-existing in `determine-version`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)