### PR TITLE
ci: run vet and the test suite in CI

### DIFF
--- a/.github/workflows/build-golang-executable-on-push.yaml
+++ b/.github/workflows/build-golang-executable-on-push.yaml
@@ -10,6 +10,18 @@ on:
   pull_request:
 
 jobs:
+  go-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        with:
+          go-version-file: go.mod
+      - name: Vet
+        run: go vet ./...
+      - name: Run tests
+        run: go test -race ./...
+
   golang-build:
     runs-on: ubuntu-latest
     strategy:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -103,6 +103,6 @@ The corollary is that **no bot can commit to `main`** here, since `GITHUB_TOKEN`
    - Builds and pushes multi-arch Docker image to `ghcr.io/thetillhoff/temingo`
    - Creates GitHub Release with artifacts
    - Updates Homebrew tap and GoReport card
-3. Manual releases: create and push a `vX.Y.Z` tag.
+3. Manual releases: merge the CHANGELOG entry to `main` first (protection leaves no other route), then tag that merged commit and push the tag.
 
 The release body comes from the `CHANGELOG.md` section for the tag, and the release fails if there is none - so a manual release needs its entry written first. Automated dependency patches have no entry: `tag-on-main` passes `release_body: "Updated dependencies."` instead, and `CHANGELOG.md` skips those version numbers.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -30,7 +30,7 @@ Temingo's core is the `Engine` struct (`pkg/temingo/Engine.go`) — all state, n
 ### Package Layout
 
 | Package | Purpose |
-|---------|---------|
+| --------- | --------- |
 | `cmd/` | CLI (urfave/cli v3), flags, config loading |
 | `pkg/temingo/` | Core engine: render pipeline, template functions, init |
 | `pkg/markdown2html/` | Goldmark-based Markdown → HTML |
@@ -40,7 +40,7 @@ Temingo's core is the `Engine` struct (`pkg/temingo/Engine.go`) — all state, n
 ### Template Variables
 
 | Variable | Type | Description |
-|----------|------|-------------|
+| ---------- | ------ | ------------- |
 | `.path` | string | Relative path from input dir |
 | `.meta` | map | Merged metadata (child overrides parent) |
 | `.childMeta` | map[string]map | Direct children's metadata, keyed by folder |
@@ -88,6 +88,12 @@ Pre-commit hooks enforce formatting, vet, tests, tidy, and golangci-lint — run
 ## Cross-Platform Builds
 
 CI builds 6 targets: `linux`, `darwin`, `windows` × `amd64`, `arm64`. The version string is injected via `-ldflags`; when built locally it defaults to `"dev"`.
+
+## Branch Protection
+
+`main` is protected: `go-test` and `verify-version` are required checks, `enforce_admins` is on, and force-pushes and deletions are refused. Direct `git push origin main` is rejected for everyone, admins included - every change lands via `gh pr merge <n> --merge --delete-branch`. Renovate is unaffected: `automergeType: branch` fast-forwards `main` to a SHA whose checks already passed.
+
+The corollary is that **no bot can commit to `main`** here, since `GITHUB_TOKEN` triggers no workflows and its commits can therefore never report the required checks. Any automation that needs a commit on `main` needs a PAT or GitHub App token - which is why the auto patch release carries its release notes as a `release_body` input instead of writing a CHANGELOG entry.
 
 ## Release Process
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -83,7 +83,7 @@ go test ./...     # equivalent
 
 Tests use `t.TempDir()` for isolation. The embedded `pkg/temingo/InitFiles/test/` project is used as a canonical rendering fixture. The main render tests are in `pkg/temingo/Render_test.go`.
 
-Pre-commit hooks enforce formatting, vet, tests, tidy, and golangci-lint — run `pre-commit install` once after cloning.
+Pre-commit hooks enforce formatting, vet, tests, tidy, and golangci-lint — run `pre-commit install` once after cloning. CI repeats `go vet ./...` and `go test -race ./...` in its `go-test` job, so a bypassed hook is caught anyway.
 
 ## Cross-Platform Builds
 


### PR DESCRIPTION
Tests only ran in pre-commit here, so nothing server-side verified them - a bypassed hook, or a renovate branch, went green on builds alone.

Adds webscan's `go-test` job: `go vet ./...` and `go test -race ./...` against the go version in `go.mod`. Since renovate now waits for a green branch (#95), this gates dependency automerge on the tests too, not just the six builds.

Passes locally: vet clean, all four test packages ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)