### PR TITLE
ci: build and version-check before tagging

### DIFF
--- a/.github/workflows/tag-on-main.yaml
+++ b/.github/workflows/tag-on-main.yaml
@@ -24,8 +24,43 @@ jobs:
 
           echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_OUTPUT
 
-  git-tag:
+  # Build the version that is about to be tagged, before the tag exists. A tag
+  # that turns out unbuildable would otherwise have to be deleted, and a
+  # re-pushed tag is permanently broken for Go module consumers: the proxy
+  # caches the first SHA it saw.
+  verify-build:
     needs: determine-version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: thetillhoff/action-golang-build@63a1bfaa47f4f5c94c6b642b0723111128a9c118 # v1.0.1
+        with:
+          OS: linux
+          ARCH: amd64
+          BUILDARGS: -ldflags="-X github.com/thetillhoff/temingo/cmd.version=${{ needs.determine-version.outputs.NEW_VERSION }}"
+
+      - name: Download artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          merge-multiple: true
+
+      - name: Verify version
+        shell: bash
+        run: |
+          chmod +x ./temingo_linux_amd64
+          VERSION_OUTPUT=$(./temingo_linux_amd64 --version 2>&1 || echo "dev")
+          VERSION_OUTPUT=$(echo "$VERSION_OUTPUT" | tr -d '\n\r' | xargs)
+          EXPECTED_VERSION="${{ needs.determine-version.outputs.NEW_VERSION }}"
+          if [[ "$VERSION_OUTPUT" != "$EXPECTED_VERSION" ]]; then
+            echo "ERROR: Version mismatch! Expected: '$EXPECTED_VERSION', Got: '$VERSION_OUTPUT'"
+            exit 1
+          fi
+          echo "✓ Version verification passed: $VERSION_OUTPUT"
+
+  git-tag:
+    needs:
+      - determine-version
+      - verify-build
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -106,3 +106,7 @@ The corollary is that **no bot can commit to `main`** here, since `GITHUB_TOKEN`
 3. Manual releases: merge the CHANGELOG entry to `main` first (protection leaves no other route), then tag that merged commit and push the tag.
 
 The release body comes from the `CHANGELOG.md` section for the tag, and the release fails if there is none - so a manual release needs its entry written first. Automated dependency patches have no entry: `tag-on-main` passes `release_body: "Updated dependencies."` instead, and `CHANGELOG.md` skips those version numbers.
+
+### A deleted tag's version number is spent
+
+`tag-on-main` builds and version-checks the commit *before* tagging it, and `release-golang-executable-on-tag`'s `cleanup-on-failure` deletes the tag if the release fails before anything is published. Both exist to keep a broken version out of the world - but **never re-push a deleted tag**. `proxy.golang.org` caches the first SHA it saw for `vX.Y.Z`, permanently, so pointing that version at a different commit gives every `go install` a checksum mismatch that no fix on our side clears. After a cleanup, fix the problem and release the next patch number.


### PR DESCRIPTION
Closes the last asymmetry with webscan: `tag-on-main` tagged first and found out afterwards, leaving `cleanup-on-failure` to delete the tag.

That order is wrong for a Go module. `proxy.golang.org` caches the first SHA it saw for `vX.Y.Z` permanently, so a deleted-and-re-pushed tag hands every `go install` a checksum mismatch that nothing on our side clears. So verify before the tag exists, and treat deletion as the fallback it is.

- New `verify-build` job: build linux/amd64 with the pending version in `-ldflags`, run `--version`, tag only on a match. Mirrors webscan.
- `cleanup-on-failure` stays in the release workflow - it covers the window *after* tagging, before anything is published.
- `DEVELOPMENT.md` records that a deleted tag's version number is spent: fix, then release the next patch, never reuse the number.

Verified with `actionlint` (exit 0; the one shellcheck note is pre-existing in `determine-version`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)