### PR TITLE
fix(ci): pass the tag explicitly on the workflow_call release path

### DIFF
--- a/.github/workflows/release-golang-executable-on-tag.yaml
+++ b/.github/workflows/release-golang-executable-on-tag.yaml
@@ -120,9 +120,13 @@ jobs:
         with:
           merge-multiple: true
 
+      # tag_name is mandatory here: the action falls back to github.ref, which is
+      # refs/heads/main when tag-on-main calls this workflow, and it refuses to
+      # release without a tag ref ("GitHub Releases requires a tag").
       - name: Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
+          tag_name: ${{ env.TAG }}
           body: "${{ needs.release-prerequisites.outputs.RELEASE_BODY }}"
           prerelease: false
           fail_on_unmatched_files: true
@@ -164,10 +168,13 @@ jobs:
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: ghcr.io/${{ github.repository }}
+          # value= for the same reason as tag_name above: semver parsing defaults
+          # to github.ref, which on the workflow_call path is a branch, so the
+          # image would get nothing but :latest.
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            type=semver,pattern={{version}},value=${{ env.TAG }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ env.TAG }}
+            type=semver,pattern={{major}},value=${{ env.TAG }}
             type=raw,value=latest
 
       - name: Build and push Docker image


### PR DESCRIPTION
The first automated release (v3.0.1, triggered by renovate merging softprops v3.0.2) tagged and built cleanly, then died:

```
##[error]⚠️ GitHub Releases requires a tag
```

`softprops/action-gh-release` infers the tag from `github.ref`. On the `workflow_call` path that is `refs/heads/main`, not a tag ref, so it refuses. `docker/metadata-action` fails the same way but silently - its `type=semver` patterns produced nothing, so the image got `:latest` as its only tag:

```
DOCKER_METADATA_OUTPUT_TAGS: ghcr.io/thetillhoff/temingo:latest
```

Latent since `trigger-release` was introduced. Every release before today came in through `on: push: tags:`, where `github.ref` *is* the tag - the first automated release was the first to take the other path. Same bug is in webscan.

Fix: pass `env.TAG` explicitly - `tag_name` on the release step, `value=${{ env.TAG }}` on each semver pattern - so both entry paths behave identically.

### v3.0.1

Keeps its tag, stays without a GitHub release. Re-pushing a tag is not an option for a Go module (proxy.golang.org caches the first SHA permanently), so the next dependency merge produces a complete v3.0.2. Go consumers are unaffected - `go install` resolves from the tag, not the release. Only the binary assets and the `3.0.1` image tags are missing.

Twelve renovate branches are still queued, so the next merge exercises the fixed path immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)