### PR TITLE
fix(ci): inherit secrets into the release workflow, serialize tag-on-main

### DIFF
--- a/.github/workflows/tag-on-main.yaml
+++ b/.github/workflows/tag-on-main.yaml
@@ -5,6 +5,14 @@ on:
     branches:
       - main
 
+# Two merges in quick succession would otherwise run in parallel, both read the
+# same `git describe` tag, and compute the same next version - one tag push wins
+# and the other fails. Serialize instead, and never cancel: a cancelled run
+# leaves a tag whose release never happened.
+concurrency:
+  group: tag-on-main
+  cancel-in-progress: false
+
 jobs:
 
   determine-version:
@@ -81,6 +89,10 @@ jobs:
       contents: write
       packages: write
     uses: ./.github/workflows/release-golang-executable-on-tag.yaml
+    # A called workflow receives no secrets unless they are passed, so
+    # HOMEBREW_TAP_ACCESS_TOKEN arrived empty in v3.0.5 and the tap update failed
+    # while the release itself succeeded.
+    secrets: inherit
     with:
       tag: ${{ needs.determine-version.outputs.NEW_VERSION }}
       # These releases get no CHANGELOG entry, so the body carries the fixed


### PR DESCRIPTION
v3.0.5 published correctly but the run is red:

```
env:
  GH_TOKEN:            ← empty
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable
```

`secrets.HOMEBREW_TAP_ACCESS_TOKEN` resolved to empty: **a called workflow receives no secrets unless the caller passes them**. So on the automated path the homebrew tap is never updated - third instance of the same class as #99, where the `workflow_call` entry point behaves differently from `on: push: tags:`. `secrets: inherit` fixes it.

Second change, a race nobody has hit yet: `tag-on-main` had no `concurrency` group. Two renovate merges close together run in parallel, both read the same `git describe` output, and compute the same next version - one tag push wins, the other fails. Today's merges were 2-8 minutes apart, which is luck, not design. Now serialized with `cancel-in-progress: false`, because cancelling mid-run is how you get a tag whose release never happened.

Same fixes go to webscan.